### PR TITLE
feat: 여행 궁합 테스트 api 추가

### DIFF
--- a/src/main/java/com/uddangtangtang/docs/TravelCompatibilityControllerDocs.java
+++ b/src/main/java/com/uddangtangtang/docs/TravelCompatibilityControllerDocs.java
@@ -1,0 +1,28 @@
+package com.uddangtangtang.docs;
+
+import com.uddangtangtang.domain.compatibility.dto.request.CompatibilityRequest;
+import com.uddangtangtang.domain.compatibility.dto.response.CompatibilityResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "여행 궁합 테스트 API")
+public interface TravelCompatibilityControllerDocs {
+
+    @Operation(summary = "여행 궁합 테스트", description = "나의 여행 유형과 상대방의 유형을 입력하면, 궁합 결과, 여행 팁, 갈등&조화 포인트, 추천 여행지를 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "궁합 테스트 성공"),
+            @ApiResponse(responseCode = "500", description = "서버 에러",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(name = "서버 에러 응답", summary = "예상치 못한 서버 에러",
+                                    value = """
+{ "success": false, "code": "COMMON_500", "message": "서버 에러, 관리자에게 문의 바랍니다." }
+""")))
+    })
+    ResponseEntity<com.uddangtangtang.global.apiPayload.ApiResponse<CompatibilityResponse>> getCompatibility(CompatibilityRequest request);
+}
+

--- a/src/main/java/com/uddangtangtang/domain/compatibility/controller/TravelCompatibilityController.java
+++ b/src/main/java/com/uddangtangtang/domain/compatibility/controller/TravelCompatibilityController.java
@@ -1,0 +1,29 @@
+package com.uddangtangtang.domain.compatibility.controller;
+
+import com.uddangtangtang.domain.compatibility.dto.request.CompatibilityRequest;
+import com.uddangtangtang.domain.compatibility.dto.response.CompatibilityResponse;
+import com.uddangtangtang.domain.compatibility.service.TravelCompatibilityService;
+import com.uddangtangtang.global.apiPayload.ApiResponse;
+import com.uddangtangtang.global.apiPayload.code.status.SuccessStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/ai/type")
+public class TravelCompatibilityController {
+    private final TravelCompatibilityService compatibilityService;
+
+    @PostMapping("/compatibility")
+    public ResponseEntity<ApiResponse<CompatibilityResponse>> getCompatibility(
+            @RequestBody CompatibilityRequest request) {
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(SuccessStatus._OK,
+                        compatibilityService.computeCompatibility(request))
+        );
+    }
+}

--- a/src/main/java/com/uddangtangtang/domain/compatibility/domain/Compatibility.java
+++ b/src/main/java/com/uddangtangtang/domain/compatibility/domain/Compatibility.java
@@ -1,0 +1,35 @@
+package com.uddangtangtang.domain.compatibility.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table( uniqueConstraints = @UniqueConstraint(columnNames = {"type_a","type_b"}))
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Compatibility {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "type_a", nullable = false)
+    private String typeA;
+
+    @Column(name = "type_b", nullable = false)
+    private String typeB;
+
+    @Lob
+    @Column(name = "response_json", columnDefinition = "LONGTEXT", nullable = false)
+    private String responseJson;
+
+    @Builder.Default
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/src/main/java/com/uddangtangtang/domain/compatibility/dto/request/CompatibilityRequest.java
+++ b/src/main/java/com/uddangtangtang/domain/compatibility/dto/request/CompatibilityRequest.java
@@ -1,0 +1,7 @@
+package com.uddangtangtang.domain.compatibility.dto.request;
+
+public record CompatibilityRequest(
+        String myType,    // null or empty if unknown
+        String otherType
+) {}
+

--- a/src/main/java/com/uddangtangtang/domain/compatibility/dto/response/CompatibilityResponse.java
+++ b/src/main/java/com/uddangtangtang/domain/compatibility/dto/response/CompatibilityResponse.java
@@ -1,0 +1,10 @@
+package com.uddangtangtang.domain.compatibility.dto.response;
+
+import java.util.List;
+
+public record CompatibilityResponse(
+        String result,
+        String tips,
+        String conflictPoints,
+        List<String> recommendations
+) {}

--- a/src/main/java/com/uddangtangtang/domain/compatibility/repository/CompatibilityRepository.java
+++ b/src/main/java/com/uddangtangtang/domain/compatibility/repository/CompatibilityRepository.java
@@ -1,0 +1,13 @@
+package com.uddangtangtang.domain.compatibility.repository;
+
+import com.uddangtangtang.domain.compatibility.domain.Compatibility;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CompatibilityRepository extends JpaRepository<Compatibility, Long> {
+    Optional<Compatibility> findByTypeAAndTypeB(String typeA, String typeB);
+}
+

--- a/src/main/java/com/uddangtangtang/domain/compatibility/service/CompatibilityLoader.java
+++ b/src/main/java/com/uddangtangtang/domain/compatibility/service/CompatibilityLoader.java
@@ -1,0 +1,34 @@
+package com.uddangtangtang.domain.compatibility.service;
+
+import com.uddangtangtang.domain.compatibility.dto.request.CompatibilityRequest;
+import com.uddangtangtang.domain.traveltype.domain.TravelType;
+import com.uddangtangtang.domain.traveltype.repository.TravelTypeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CompatibilityLoader implements CommandLineRunner {
+    private final TravelTypeRepository typeRepo;
+    private final TravelCompatibilityService compatibilityService;
+
+    @Override
+    public void run(String... args) {
+        List<String> codes = typeRepo.findAll().stream().map(TravelType::getCode).toList();
+        for (int i = 0; i < codes.size(); i++) {
+            for (int j = i; j < codes.size(); j++) {
+                String my = codes.get(i);
+                String other = codes.get(j);
+                compatibilityService.computeCompatibility(
+                        new CompatibilityRequest(my.equals("?") ? "" : my, other));
+                log.info("Preloaded compatibility: {} - {}", my, other);
+            }
+        }
+    }
+}
+

--- a/src/main/java/com/uddangtangtang/domain/compatibility/service/TravelCompatibilityService.java
+++ b/src/main/java/com/uddangtangtang/domain/compatibility/service/TravelCompatibilityService.java
@@ -1,0 +1,84 @@
+package com.uddangtangtang.domain.compatibility.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.uddangtangtang.domain.compatibility.domain.Compatibility;
+import com.uddangtangtang.domain.compatibility.dto.request.CompatibilityRequest;
+import com.uddangtangtang.domain.compatibility.dto.response.CompatibilityResponse;
+import com.uddangtangtang.domain.compatibility.repository.CompatibilityRepository;
+import com.uddangtangtang.global.ai.service.AiService;
+import com.uddangtangtang.global.apiPayload.code.status.ErrorStatus;
+import com.uddangtangtang.global.apiPayload.exception.GeneralException;
+import com.uddangtangtang.global.util.AiCompatibilityPromptBuilder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TravelCompatibilityService {
+    private final AiService aiService;
+    private final ObjectMapper objectMapper;
+    private final CompatibilityRepository compatibilityRepo;
+
+    public CompatibilityResponse computeCompatibility(CompatibilityRequest request) {
+        String t1 = request.myType() == null || request.myType().isBlank()
+                ? "?" : request.myType();
+        String t2 = request.otherType();
+        String typeA = t1.compareTo(t2) <= 0 ? t1 : t2;
+        String typeB = t1.compareTo(t2) <= 0 ? t2 : t1;
+
+        Optional<Compatibility> cached = compatibilityRepo.findByTypeAAndTypeB(typeA, typeB);
+        if (cached.isPresent()) {
+            try {
+                String json = cached.get().getResponseJson();
+                JsonNode node = objectMapper.readTree(json);
+                return parseJson(node);
+            } catch (Exception e) {
+                log.warn("Cache parse error, regenerating AI response", e);
+            }
+        }
+
+        String prompt = AiCompatibilityPromptBuilder.buildPrompt(request);
+        String aiRaw = aiService.askChatGPT(prompt).block();
+        log.info("AI compatibility raw: {}", aiRaw);
+        CompatibilityResponse resp = parseRaw(aiRaw);
+
+        try {
+            String jsonResp = objectMapper.writeValueAsString(resp);
+            Compatibility entry = Compatibility.builder()
+                    .typeA(typeA)
+                    .typeB(typeB)
+                    .responseJson(jsonResp)
+                    .build();
+            compatibilityRepo.save(entry);
+        } catch (Exception e) {
+            log.warn("Failed to save compatibility cache", e);
+        }
+        return resp;
+    }
+
+    private CompatibilityResponse parseRaw(String raw) {
+        try {
+            JsonNode node = objectMapper.readTree(raw);
+            return parseJson(node);
+        } catch (Exception e) {
+            log.error("AI parse error in compatibility", e);
+            throw new GeneralException(ErrorStatus.AI_PARSE_ERROR);
+        }
+    }
+
+    private CompatibilityResponse parseJson(JsonNode node) {
+        String result = node.path("result").asText();
+        String tips = node.path("tips").asText();
+        String conflict = node.path("conflictPoints").asText();
+        List<String> recs = new ArrayList<>();
+        node.withArray("recommendations").forEach(n -> recs.add(n.asText()));
+        return new CompatibilityResponse(result, tips, conflict, recs);
+    }
+}

--- a/src/main/java/com/uddangtangtang/global/util/AiCompatibilityPromptBuilder.java
+++ b/src/main/java/com/uddangtangtang/global/util/AiCompatibilityPromptBuilder.java
@@ -1,0 +1,32 @@
+package com.uddangtangtang.global.util;
+
+import com.uddangtangtang.domain.compatibility.dto.request.CompatibilityRequest;
+
+public class AiCompatibilityPromptBuilder {
+    public static String buildPrompt(CompatibilityRequest request) {
+        String myType = request.myType();
+        String otherType = request.otherType();
+        String prompt = """
+너는 여행 궁합 전문가야.
+아래 JSON 형식으로만 응답해라.
+결과에는 다음 필드를 포함해라:
+- \"result\": 궁합 결과(3줄)
+- \"tips\": 함께하는 여행 팁(3줄)
+- \"conflictPoints\": 갈등&조화 포인트(3줄)
+- \"recommendations\": 추천 여행지 3곳을 배열에 담아라. 각 요소는 \"장소: 간단한 코스\" 형식.
+JSON 예시:
+{
+  \"result\": \"...\",
+  \"tips\": \"...\",
+  \"conflictPoints\": \"...\",
+  \"recommendations\": [\"코스1\", \"코스2\", \"코스3\"]
+}
+""";
+        if (myType == null || myType.isBlank()) {
+            prompt += String.format("나의 유형: (모름)\n상대방의 유형: %s\n", otherType);
+        } else {
+            prompt += String.format("나의 유형: %s\n상대방의 유형: %s\n", myType, otherType);
+        }
+        return prompt;
+    }
+}


### PR DESCRIPTION
feat: 여행 궁합 테스트 API 및 캐시 기능 추가

## 작업 목적 (Why?)
여행 유형 테스트 이후, 두 사용자의 여행 궁합을 AI 기반으로 즉시 조회하고  
동일 조합에 대해 항상 같은 결과를 DB에서 캐싱해서 빠르게 재응답하기 위해 추가합니다.

## 주요 변경 사항 (What?)
- **엔티티**: `Compatibility` (typeA/typeB, LONGTEXT `response_json`, `created_at` 기본값)  
- **리포지토리**: `CompatibilityRepository`  
- **서비스**: `TravelCompatibilityService`  
  - 사전순 정렬로 키 생성  
  - 캐시 조회 → AI 호출 → DB 저장 로직  
- **로더**: `CompatibilityLoader`  
  - 애플리케이션 구동 시 36가지 조합 캐싱  
- **컨트롤러**:  
  - `POST /ai/type/compatibility` 추가  
  - Swagger 문서화를 위한 `TravelCompatibilityControllerDocs` 인터페이스  
- **DB 스키마 변경**:  
  - `response_json` 컬럼 타입 → `LONGTEXT`  
  - `created_at` 필드 기본값 `@Builder.Default` 적용  

## 검증 방법 (How to Test)
1. 애플리케이션 재시작 후 로그에서 36건 캐시 로드(`Preloaded compatibility: ...`) 확인  
2. Postman 호출  
   - URL: `POST http://localhost:8080/ai/type/compatibility`  
   - Header: `Content-Type: application/json`  
   - Body:
     ```json
     {
       "myType": "A-B-A",
       "otherType": "B-A-B"
     }
     ```
   - 응답에 `result`, `tips`, `conflictPoints`, `recommendations` 필드 확인  
   - 동일 조합 재호출 시 AI 호출 없이 즉시 DB 응답 확인  
3. Swagger UI에서 “여행 궁합 테스트 API” 섹션 및 예시 확인  

## 마이그레이션 및 설정
- DB에 `compatibility_cache` 테이블 생성 여부 확인 (DDL-auto 또는 마이그레이션 스크립트)  
- `response_json` 컬럼이 `LONGTEXT` 타입인지 확인  
- OpenAI API 키 설정 및 `/ai/type/test` API 정상 동작 확인  

## 체크리스트 (Checklist)
- [ ] 빌드 및 컴파일 오류 없음  
- [ ] Postman/통합 테스트 통과  
- [ ] Swagger 문서 반영 확인  
- [ ] DB 컬럼 타입 변경 사항 반영  
- [ ] 코드·로직 리뷰 완료  



같은 유형인 경우, 다른 유형인 경우를 총 합해서 36가지를 db에 넣어서 db에서 가져오도록 했습니다! 
