### PR TITLE
fix: 여행 유형을 A-A-B 형식이 아닌 계획충 쉴러 곰 이런 방식으로 변경

### DIFF
--- a/src/main/java/com/uddangtangtang/domain/compatibility/dto/request/CompatibilityRequest.java
+++ b/src/main/java/com/uddangtangtang/domain/compatibility/dto/request/CompatibilityRequest.java
@@ -1,7 +1,7 @@
 package com.uddangtangtang.domain.compatibility.dto.request;
 
 public record CompatibilityRequest(
-        String myType,    // null or empty if unknown
-        String otherType
-) {}
-
+        String myType,    // 현재는 코드(e.g. "A-B-A")
+        String otherType  // 현재는 코드(e.g. "B-A-B")
+) {
+}

--- a/src/main/java/com/uddangtangtang/domain/compatibility/service/CompatibilityLoader.java
+++ b/src/main/java/com/uddangtangtang/domain/compatibility/service/CompatibilityLoader.java
@@ -19,14 +19,22 @@ public class CompatibilityLoader implements CommandLineRunner {
 
     @Override
     public void run(String... args) {
-        List<String> codes = typeRepo.findAll().stream().map(TravelType::getCode).toList();
-        for (int i = 0; i < codes.size(); i++) {
-            for (int j = i; j < codes.size(); j++) {
-                String my = codes.get(i);
-                String other = codes.get(j);
-                compatibilityService.computeCompatibility(
-                        new CompatibilityRequest(my.equals("?") ? "" : my, other));
-                log.info("Preloaded compatibility: {} - {}", my, other);
+        // 1) TravelType 엔티티에서 typeName(예: "무념무상 힐링러")을 뽑아온다
+        List<String> names = typeRepo.findAll().stream()
+                .map(TravelType::getTypeName)
+                .toList();
+
+        // 2) 이중 루프로 i ≤ j 순서로 조합
+        for (int i = 0; i < names.size(); i++) {
+            for (int j = i; j < names.size(); j++) {
+                String myName    = names.get(i);
+                String otherName = names.get(j);
+                // 3) typeName 기반 새로운 DTO를 만든 뒤, 서비스 호출
+                CompatibilityRequest req =
+                        new CompatibilityRequest(myName, otherName);
+
+                compatibilityService.computeCompatibility(req);
+                log.info("Preloaded compatibility by name: {} - {}", myName, otherName);
             }
         }
     }

--- a/src/main/java/com/uddangtangtang/domain/compatibility/service/TravelCompatibilityService.java
+++ b/src/main/java/com/uddangtangtang/domain/compatibility/service/TravelCompatibilityService.java
@@ -8,7 +8,8 @@ import com.uddangtangtang.domain.compatibility.dto.request.CompatibilityRequest;
 import com.uddangtangtang.domain.compatibility.dto.response.CompatibilityResponse;
 import com.uddangtangtang.domain.compatibility.repository.CompatibilityRepository;
 import com.uddangtangtang.domain.compatibility.repository.CompatibilityResultRepository;
-import com.uddangtangtang.domain.traveltype.domain.TravelTypeTestResult;
+import com.uddangtangtang.domain.traveltype.domain.TravelType;
+import com.uddangtangtang.domain.traveltype.repository.TravelTypeRepository;
 import com.uddangtangtang.global.ai.service.AiService;
 import com.uddangtangtang.global.apiPayload.code.status.ErrorStatus;
 import com.uddangtangtang.global.apiPayload.exception.GeneralException;
@@ -34,9 +35,13 @@ public class TravelCompatibilityService {
     private final ObjectMapper objectMapper;
     private final CompatibilityRepository compatibilityRepo;
     private final CompatibilityResultRepository compatibilityResultRepo;
+    private final TravelTypeRepository travelTypeRepository;
+
+
 
     @Transactional
     public CompatibilityResponse computeCompatibility(CompatibilityRequest request) {
+
         String t1 = request.myType() == null || request.myType().isBlank() ? "?" : request.myType();
         String t2 = request.otherType();
         String typeA = t1.compareTo(t2) <= 0 ? t1 : t2;

--- a/src/main/java/com/uddangtangtang/domain/traveltype/repository/TravelTypeRepository.java
+++ b/src/main/java/com/uddangtangtang/domain/traveltype/repository/TravelTypeRepository.java
@@ -12,4 +12,5 @@ public interface TravelTypeRepository extends JpaRepository<TravelType, Long>, C
 {
     Optional<TravelType> findTravelTypeByCode(String code);
     Optional<TravelType> findTravelTypeById(Long type_id);
+    Optional<TravelType> findByTypeName(String typeName);
 }

--- a/src/main/java/com/uddangtangtang/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/uddangtangtang/global/apiPayload/code/status/ErrorStatus.java
@@ -25,6 +25,8 @@ public enum ErrorStatus implements BaseErrorCode {
     /* ===== 공유 유형 생성 ===== */
     RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "TRAVEL_TYPE_001", "해당 테스트 결과가 존재하지 않습니다."),
 
+    NULL_IS_NOT_ALLOWED(HttpStatus.NOT_FOUND,"TRAVEL_TYPE_001","여행 유형은 빈 값이어서는 안 됩니다"),
+
     /* ===== 검증/리소스 ===== */
     VALIDATION_ERROR ("COMMON400A", "유효성 검증 실패"),
     NOT_FOUND        (HttpStatus.NOT_FOUND, "COMMON404", "리소스를 찾을 수 없습니다.")


### PR DESCRIPTION
예전에 두 개의 여행 유형을 받아서 여행 궁합 테스트를 할 때 여행 유형을 A-A-B 이런 형식으로 받아서 
로직을 약간 수정하여 여행 유형을 "계획충 쉴러 곰" 이런 형식으로 바꾸도록 수정했습니다. 
이렇게 하니까 여행 추천지도 다양화되었습니다. 